### PR TITLE
Conffolder Linux

### DIFF
--- a/lib/platformDep.py
+++ b/lib/platformDep.py
@@ -3,8 +3,23 @@ import platform
 
 def getNamecoinDir():
     if platform.system() == "Darwin":
-        return os.path.expanduser("~/Library/Application Support/Namecoin/")
+        return os.path.expanduser("~/Library/Application Support/Namecoin")
     elif platform.system() == "Windows":
         return os.path.join(os.environ['APPDATA'], "Namecoin")
     return os.path.expanduser("~/.namecoin")
 
+def getNmcontrolDir():  # may be overwritten in nmcontrol.py
+    if platform.system() == "Darwin":
+        return os.path.expanduser("~/Library/Application Support/Nmcontrol")
+    elif platform.system() == "Windows":
+        return os.path.join(os.environ['APPDATA'], "Nmcontrol")
+
+    try:
+        st = os.stat('/var/lib/nmcontrol')
+        haspermission = bool(st.st_mode & stat.S_IRGRP)
+    except OSError:
+        haspermission = False
+    if haspermission:
+        return '/var/lib/nmcontrol'
+    else:
+        return os.path.expanduser("~/.config/nmcontrol")

--- a/nmcontrol.py
+++ b/nmcontrol.py
@@ -15,12 +15,16 @@ def main():
     app['conf'] = ConfigParser.SafeConfigParser()
     app['path'] = {}
     app['path']['app'] = os.path.dirname(os.path.realpath(__file__)) + os.sep
-    app['path']['conf'] = app['path']['app'] + os.sep + 'conf' + os.sep
 
     # add import path
     sys.path.append(app['path']['app'] + 'lib')
     sys.path.append(app['path']['app'] + 'plugin')
     sys.path.append(app['path']['app'] + 'service')
+
+    # add conf path
+    import platformDep
+    app['path']['conf'] = os.path.join(platformDep.getNmcontrolDir(),
+                                       'conf') + os.sep
 
     import common
     common.app = app


### PR DESCRIPTION
Use the correct OS dependent conf folder for linux. Now uses the following directories depending on whether the process has permissions to write to them:

/var/lib/nmcontrol
~/.config/nmcontral
